### PR TITLE
Prepare for release 7.2.0-v6

### DIFF
--- a/charts/stash-elasticsearch/Chart.yaml
+++ b/charts/stash-elasticsearch/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: 'stash-elasticsearch - Elasticsearch database plugin for Stash by AppsCode'
 name: stash-elasticsearch
-version: 7.2.0-v5
-appVersion: 7.2.0-v5
+version: 7.2.0-v6
+appVersion: 7.2.0-v6
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/addons/elasticsearch-stash-addon.png
 sources:

--- a/charts/stash-elasticsearch/README.md
+++ b/charts/stash-elasticsearch/README.md
@@ -7,7 +7,7 @@
 ```console
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm install stash-elasticsearch-7.2.0-v5 appscode/stash-elasticsearch -n kube-system --version=7.2.0-v5
+$ helm install stash-elasticsearch-7.2.0-v6 appscode/stash-elasticsearch -n kube-system --version=7.2.0-v6
 ```
 
 ## Introduction
@@ -20,10 +20,10 @@ This chart deploys necessary `Function` and `Task` definition to backup or resto
 
 ## Installing the Chart
 
-To install the chart with the release name `stash-elasticsearch-7.2.0-v5`:
+To install the chart with the release name `stash-elasticsearch-7.2.0-v6`:
 
 ```console
-$ helm install stash-elasticsearch-7.2.0-v5 appscode/stash-elasticsearch -n kube-system --version=7.2.0-v5
+$ helm install stash-elasticsearch-7.2.0-v6 appscode/stash-elasticsearch -n kube-system --version=7.2.0-v6
 ```
 
 The command deploys necessary `Function` and `Task` definition to backup or restore Elasticsearch 7.2.0 using Stash on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -32,10 +32,10 @@ The command deploys necessary `Function` and `Task` definition to backup or rest
 
 ## Uninstalling the Chart
 
-To uninstall/delete the `stash-elasticsearch-7.2.0-v5`:
+To uninstall/delete the `stash-elasticsearch-7.2.0-v6`:
 
 ```console
-$ helm delete stash-elasticsearch-7.2.0-v5 -n kube-system
+$ helm delete stash-elasticsearch-7.2.0-v6 -n kube-system
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
@@ -50,7 +50,7 @@ The following table lists the configurable parameters of the `stash-elasticsearc
 | fullnameOverride | Overrides fullname template                                                                                                         | `""`                  |
 | image.registry   | Docker registry used to pull Elasticsearch addon image                                                                              | `stashed`             |
 | image.repository | Docker image used to backup/restore Elasticsearch database                                                                          | `stash-elasticsearch` |
-| image.tag        | Tag of the image that is used to backup/restore Elasticsearch database. This is usually same as the database version it can backup. | `7.2.0-v5`            |
+| image.tag        | Tag of the image that is used to backup/restore Elasticsearch database. This is usually same as the database version it can backup. | `7.2.0-v6`            |
 | backup.args      | Arguments to pass to `multielasticdump` command  during backup process                                                              | `""`                  |
 | restore.args     | Arguments to pass to `multielasticdump` command during restore process                                                              | `""`                  |
 | waitTimeout      | Number of seconds to wait for the database to be ready before backup/restore process.                                               | `300`                 |
@@ -59,12 +59,12 @@ The following table lists the configurable parameters of the `stash-elasticsearc
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
 ```console
-$ helm install stash-elasticsearch-7.2.0-v5 appscode/stash-elasticsearch -n kube-system --version=7.2.0-v5 --set image.registry=stashed
+$ helm install stash-elasticsearch-7.2.0-v6 appscode/stash-elasticsearch -n kube-system --version=7.2.0-v6 --set image.registry=stashed
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```console
-$ helm install stash-elasticsearch-7.2.0-v5 appscode/stash-elasticsearch -n kube-system --version=7.2.0-v5 --values values.yaml
+$ helm install stash-elasticsearch-7.2.0-v6 appscode/stash-elasticsearch -n kube-system --version=7.2.0-v6 --values values.yaml
 ```

--- a/charts/stash-elasticsearch/doc.yaml
+++ b/charts/stash-elasticsearch/doc.yaml
@@ -10,11 +10,11 @@ repository:
   name: appscode
 chart:
   name: stash-elasticsearch
-  version: 7.2.0-v5
+  version: 7.2.0-v6
   values: "-- generate from values file --"
   valuesExample: "-- generate from values file --"
 prerequisites:
 - Kubernetes 1.11+
 release:
-  name: stash-elasticsearch-7.2.0-v5
+  name: stash-elasticsearch-7.2.0-v6
   namespace: kube-system

--- a/charts/stash-elasticsearch/values.yaml
+++ b/charts/stash-elasticsearch/values.yaml
@@ -13,7 +13,7 @@ image:
   repository: stash-elasticsearch
   # Tag of the image that is used to backup/restore Elasticsearch database.
   # This is usually same as the database version it can backup.
-  tag: 7.2.0-v5
+  tag: 7.2.0-v6
 # optional argument to send multielasticdump
 backup:
   # Arguments to pass to `multielasticdump` command  during backup process

--- a/docs/examples/backup/backupconfiguration.yaml
+++ b/docs/examples/backup/backupconfiguration.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   schedule: "*/5 * * * *"
   task:
-    name: elasticsearch-backup-7.2.0-v5
+    name: elasticsearch-backup-7.2.0-v6
   repository:
     name: gcs-repo
   target:

--- a/docs/examples/restore/restoresession.yaml
+++ b/docs/examples/restore/restoresession.yaml
@@ -7,7 +7,7 @@ metadata:
     kubedb.com/kind: Elasticsearch # this label is mandatory if you are using KubeDB to deploy the database. Otherwise, Elasticsearch crd will be stuck in `Initializing` phase.
 spec:
   task:
-    name: elasticsearch-restore-7.2.0-v5
+    name: elasticsearch-restore-7.2.0-v6
   repository:
     name: gcs-repo
   target:

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	kmodules.xyz/custom-resources v0.0.0-20201124062543-bd8d35c21b0c
 	kmodules.xyz/offshoot-api v0.0.0-20201105074700-8675f5f686f2
 	kmodules.xyz/schema-checker v0.1.0
-	stash.appscode.dev/apimachinery v0.11.8
+	stash.appscode.dev/apimachinery v0.11.9
 )
 
 replace bitbucket.org/ww/goautoneg => gomodules.xyz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/go.sum
+++ b/go.sum
@@ -995,8 +995,6 @@ k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89 h1:d4vVOjXm687F1iLSP2q3lyPPuyvTU
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 kmodules.xyz/client-go v0.0.0-20201105071625-0b277310b9b8 h1:zs2+yI/Ola5HjdtfP29XD76Bx5BO4WchC2uN9lkhxQM=
 kmodules.xyz/client-go v0.0.0-20201105071625-0b277310b9b8/go.mod h1:WXDwZBmvrcLgGcuO9iZpI9jcfPuDFfWbxA4EnhAFtGw=
-kmodules.xyz/client-go v0.0.0-20201208053851-a1d7be95e006 h1:gNrNTwi0jViRqdszsb0W5CQF+ANNVFlvh/LO0A3R7dM=
-kmodules.xyz/client-go v0.0.0-20201208053851-a1d7be95e006/go.mod h1:WXDwZBmvrcLgGcuO9iZpI9jcfPuDFfWbxA4EnhAFtGw=
 kmodules.xyz/client-go v0.0.0-20210108092221-c3812eb92bd0 h1:VHpZt3cG/yY6UrA3vjoUc4pJtc/jVbjt2A3OPuMXBOQ=
 kmodules.xyz/client-go v0.0.0-20210108092221-c3812eb92bd0/go.mod h1:WXDwZBmvrcLgGcuO9iZpI9jcfPuDFfWbxA4EnhAFtGw=
 kmodules.xyz/constants v0.0.0-20200923054614-6b87dbbae4d6/go.mod h1:DbiFk1bJ1KEO94t1SlAn7tzc+Zz95rSXgyUKa2nzPmY=
@@ -1033,6 +1031,6 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=
-stash.appscode.dev/apimachinery v0.11.8 h1:Po7gDpZqd+iQ8DR3zu1iJgIPQiFODPjiA6NIKhO2+7s=
-stash.appscode.dev/apimachinery v0.11.8/go.mod h1:s91NxOW9K/CLv9Cl9XVCzBLgdKqVcUOyc9VrYg0NNB0=
+stash.appscode.dev/apimachinery v0.11.9 h1:rTGXRrwxRSuM3bwA8W1x2PuXPQtmwUA3PL7wO5iVH5k=
+stash.appscode.dev/apimachinery v0.11.9/go.mod h1:Ixnv6Oq7O6XgofgEDrbQhvFCZu2t4XDx16dPgMsxnUM=
 vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -475,7 +475,7 @@ kmodules.xyz/schema-checker
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.11.8
+# stash.appscode.dev/apimachinery v0.11.9
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories
 stash.appscode.dev/apimachinery/apis/repositories/v1alpha1


### PR DESCRIPTION
ProductLine: Stash
Release: v2021.01.21
Release-tracker: https://github.com/stashed/CHANGELOG/pull/27
Signed-off-by: 1gtm <1gtm@appscode.com>